### PR TITLE
Add Support for Telegram Channel Topic ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     secrets:
       telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
       telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      telegram_topic_id: ${{ secrets.TELEGRAM_TOPIC_ID }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,4 @@ jobs:
     secrets:
       telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
       telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+      telegram_topic_id: ${{ secrets.TELEGRAM_TOPIC_ID }}

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -17,6 +17,9 @@ on:
       telegram_chat_id:
         description: "Telegram chat id"
         required: true
+      telegram_topic_id:
+        description: "The topic ID for a specific discussion in a channel"
+        required: false
 
 jobs:
   test:
@@ -43,12 +46,14 @@ jobs:
         with:
           telegram_bot_token: ${{ secrets.telegram_bot_token }}
           telegram_chat_id: ${{ secrets.telegram_chat_id }}
+          telegram_topic_id: ${{ secrets.telegram_topic_id }}
           message: ${{ inputs.message }}
 
       - uses: ./
         with:
           telegram_bot_token: ${{ secrets.telegram_bot_token }}
           telegram_chat_id: ${{ secrets.telegram_chat_id }}
+          telegram_topic_id: ${{ secrets.telegram_topic_id }}
           message: ${{ inputs.message }}
           imageUrl: ${{ inputs.imageUrl }}
 
@@ -56,4 +61,5 @@ jobs:
         with:
           telegram_bot_token: ${{ secrets.telegram_bot_token }}
           telegram_chat_id: ${{ secrets.telegram_chat_id }}
+          telegram_topic_id: ${{ secrets.telegram_topic_id }}
           imageUrl: ${{ inputs.imageUrl }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Telegram Notifier
+# Telegram Notifier for SuperGroups
 
 A GitHub Action that enables you to send messages and images to Telegram chats, channels, or specific topics in supergroups using the Telegram Bot API.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,45 @@
 # Telegram Notifier
 
-This GitHub Action allows you to send messages and images to a Telegram chat using the Telegram Bot API.
+A GitHub Action that enables you to send messages and images to Telegram chats, channels, or specific topics in supergroups using the Telegram Bot API.
+
+## Table of Contents
+
+- [Features](#features)
+- [Inputs](#inputs)
+- [Usage](#usage)
+    - [Example Workflow: Send a Message](#example-workflow-send-a-message)
+    - [Example Workflow: Send an Image](#example-workflow-send-an-image)
+- [How It Works](#how-it-works)
+- [Contributing](#contributing)
+
+---
+
+## Features
+
+- Send text messages to a Telegram chat or channel.
+- Attach images by providing their URL.
+- Target specific topics in Telegram supergroups using `telegram_topic_id` (optional).
+
+---
+
+## Inputs
+
+| Input               | Required | Description                                                                 |
+|---------------------|----------|-----------------------------------------------------------------------------|
+| `telegram_bot_token` | Yes      | The unique token provided by the Telegram Bot API for authorization.       |
+| `telegram_chat_id`   | Yes      | The unique identifier for the Telegram chat or channel.                    |
+| `telegram_topic_id`  | No       | The unique identifier for the specific topic in supergroups or channels.   |
+| `message`            | No       | The content of the message to send.                                        |
+| `imageUrl`           | No       | The URL of the image to download and send.                                 |
+
+---
 
 ## Usage
 
-### Inputs
-
-- `telegram_bot_token` (required): The unique token provided by the Telegram Bot API for authorization.
-- `telegram_chat_id` (required): The unique identifier for the Telegram chat or channel where you want to send the message or image.
-- `message` (optional): The content of the message you want to send.
-- `imageUrl` (optional): The URL of the image you want to download and send.
-
-### Example Workflow
+### Example Workflow: Send a Message
 
 ```yaml
-name: Telegram Notifier
+name: Telegram Notifier - Send Message
 
 on:
   push:
@@ -30,8 +55,21 @@ jobs:
         with:
           telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          telegram_topic_id: ${{ secrets.TELEGRAM_TOPIC_ID }} # Optional
           message: 'Hello from GitHub Actions!'
+```
 
+### Example Workflow: Send an Image
+
+```yaml
+name: Telegram Notifier - Send Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
   send_image:
     runs-on: ubuntu-latest
     steps:
@@ -40,15 +78,29 @@ jobs:
         with:
           telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          telegram_topic_id: ${{ secrets.TELEGRAM_TOPIC_ID }} # Optional
           imageUrl: 'https://example.com/image.jpg'
 ```
-
 ## How It Works
-- The action downloads an image from a given URL and saves it with a specified file name.
-- It then sends the image to a Telegram chat using the Telegram Bot API.
+
+1. The action uses the provided Telegram Bot API token for authentication.
+2. If sending an image:
+    - The action downloads the image from the given URL.
+    - The image is sent to the specified Telegram chat or channel.
+3. For supergroups, you can optionally specify a `telegram_topic_id` to target a specific topic.
+
+---
 
 ## Contributing
-If you'd like to contribute to this project, please create a pull request.
 
+We welcome contributions to improve this GitHub Action! To contribute:
 
-### You can replace the placeholders like `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` with your actual secrets. This `README.md` provides clear instructions on how to use your GitHub Action. If you have any specific details or additional information you'd like to include, please let me know!
+1. Fork the repository.
+2. Create a new branch for your feature or bug fix.
+3. Submit a pull request with a clear description of your changes.
+
+---
+
+## Notes
+
+Replace the placeholders (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `TELEGRAM_TOPIC_ID`) with your actual secrets in your workflow configuration.

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   telegram_chat_id:
     description: "Telegram chat id"
     required: true
+  telegram_topic_id:
+    description: "The topic ID for a specific discussion in a channel"
+    required: false
   message:
     description: "Message to send"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: "Send Message On Telegram"
-description: "Send a message to a telegram chat"
+name: "Send Message On Telegram for Super Groups"
+description: "Send a message to a telegram chat and super groups"
 
 branding:
-  icon: "bell"
-  color: "blue"
+  icon: "check-circle"
+  color: "purple"
 
 inputs:
   telegram_bot_token:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "telegram_notifier",
+  "name": "telegram_notifier_for_supergroups",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,14 +63,27 @@ async function sendImage(
  * @param {string} telegram_chat_id - The `telegram_chat_id` parameter is the unique identifier for the
  * Telegram chat or channel where you want to send the message. It can be a numeric ID for a chat or a
  * username for a channel.
+ * @param telegram_topic_id - The `telegram_id` parameter is an optional attribute for cases that you want to send
+ * messages to a telegram super channel with different topics, and it should be a number.
  */
 async function sendMessage(
-  message: string,
-  telegram_bot_token: string,
-  telegram_chat_id: string
+    message: string,
+    telegram_bot_token: string,
+    telegram_chat_id: string,
+    telegram_topic_id?: string
 ) {
   try {
-    const url = `https://api.telegram.org/bot${telegram_bot_token}/sendMessage?chat_id=${telegram_chat_id}&text=${message}`;
+    // Base URL for sending messages
+    let url = `https://api.telegram.org/bot${telegram_bot_token}/sendMessage?chat_id=${telegram_chat_id}&text=${encodeURIComponent(
+        message
+    )}`;
+
+    // Add topic ID if provided
+    if (telegram_topic_id) {
+      url += `&message_thread_id=${telegram_topic_id}`;
+    }
+
+    // Send the request
     await axios.get(url);
   } catch (error: any) {
     core.setFailed(error.message);
@@ -96,6 +109,7 @@ async function main() {
     const telegram_chat_id = core.getInput("telegram_chat_id", {
       required: true,
     });
+    const telegram_topic_id = core.getInput("telegram_topic_id", { required: false });
     const message = core.getInput("message", { required: false });
     const imageUrl = core.getInput("imageUrl", {
       required: false,
@@ -109,7 +123,7 @@ async function main() {
     }
     if (message) {
       console.log("Sending message...");
-      await sendMessage(message, telegram_bot_token, telegram_chat_id);
+      await sendMessage(message, telegram_bot_token, telegram_chat_id, telegram_topic_id);
       console.log("Message sent successfully!");
     }
   } catch (error: any) {


### PR DESCRIPTION
This pull request introduces support for sending messages to specific topics within Telegram supergroups or channels by adding the ability to include a Topic ID (message_thread_id) when sending notifications.

### Key Changes

1. Enhanced sendMessage Function:
    - Added a new optional parameter, telegram_topic_id, to include the message_thread_id when constructing the Telegram Bot API request.
    - Dynamically appends message_thread_id to the API URL if telegram_topic_id is provided.
2. Updated Workflow Integration:
    - Modified the main function to accept a telegram_topic_id input from the GitHub Action workflow.
    - Ensures backward compatibility by making telegram_topic_id optional.
3. Workflow File Update:
    - Added telegram_topic_id as a configurable input in the GitHub Actions YAML workflow file.

### Benefits

- Enables targeting specific discussion topics within a Telegram supergroup or channel, improving flexibility and precision for notifications.
- Maintains compatibility for general notifications if no telegram_topic_id is provided.

### Testing

- Verified that messages are correctly sent to the intended topic when a valid telegram_topic_id is specified.
- Confirmed that notifications work as usual when telegram_topic_id is omitted.

### Notes
This update is particularly useful for users managing large Telegram supergroups with multiple topics, ensuring messages are organized and delivered to the right audience.